### PR TITLE
Flutter 3.0 Migration

### DIFF
--- a/lib/src/fading_edge_scrollview.dart
+++ b/lib/src/fading_edge_scrollview.dart
@@ -192,7 +192,7 @@ class _FadingEdgeScrollViewState extends State<FadingEdgeScrollView>
     _isScrolledToStart = _controller.initialScrollOffset == 0;
     _controller.addListener(_onScroll);
 
-    WidgetsBinding.instance?.let((it) {
+    WidgetsBinding.instance.let((it) {
       it.addPostFrameCallback(_postFrameCallback);
       it.addObserver(this);
     });
@@ -217,7 +217,7 @@ class _FadingEdgeScrollViewState extends State<FadingEdgeScrollView>
 
   @override
   void dispose() {
-    WidgetsBinding.instance?.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
     _controller.removeListener(_onScroll);
     if (widget.shouldDisposeScrollController) {


### PR DESCRIPTION
Issue: #16 

WidgetsBinding.instance is not nullable in flutter 3.0.
To avoid exceptions, we should remove null safety operators which are currently used with WidgetsBinding.instance.